### PR TITLE
Redução do tempo dos convidados

### DIFF
--- a/principal/disposicoes-fundamentais.tex
+++ b/principal/disposicoes-fundamentais.tex
@@ -80,7 +80,7 @@
 	\end{xparagraph}
 
 	\begin{xparagraph}
-		A entidade \textbf{convidada} que participar de \textbf{duas edições consecutivas} do \textbf{INTERCOMP} poderá pleitear um \textbf{cargo na CO Executiva} na edição seguinte.
+		A entidade \textbf{convidada} que participar de \textbf{uma edição} do \textbf{INTERCOMP} poderá pleitear um \textbf{cargo na CO Executiva} na edição seguinte.
 	\end{xparagraph}
 
 	\begin{xparagraph}
@@ -93,7 +93,7 @@
 \end{article}
 
 \begin{article}
-	Ao completarem-se dois anos de participação de uma entidade \textbf{convidada}, as entidades \textbf{integrantes} deverão votar sua efetivação ou remoção da \textbf{INTERCOMP}. É necessária maioria absoluta para remoção, dessa forma a entidade não participará da edição imediatamente seguinte. Caso contrário a entidade será automaticamente classificada como \textbf{participante} na edição seguinte. Uma entidade \textbf{convidada} que não foi efetivada pode voltar a ser convidada em edições futuras.
+	Ao completarem-se um ano de participação de uma entidade \textbf{convidada}, as entidades \textbf{integrantes} deverão votar sua efetivação ou remoção da \textbf{INTERCOMP}. É necessária maioria absoluta para remoção, dessa forma a entidade não participará da edição imediatamente seguinte. Caso contrário a entidade será automaticamente classificada como \textbf{participante} na edição seguinte. Uma entidade \textbf{convidada} que não foi efetivada pode voltar a ser convidada em edições futuras.
 \end{article}
 
 \begin{article}


### PR DESCRIPTION
Conforme discutido e aprovado em reunião, entidades que forem ao inter como convidadas por 1 ano (não mais 2) já podem ser votadas como participantes.